### PR TITLE
docs: clarify TSV file usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ of malware and hence it is an important feature.
 
 # Feature Encoding
 The above-mentioned features are extracted from the AndroidManifest.xml and
-.smali file and converted into a tsv (Tab separated values) file. This csv file is then
-encoded into another tsv(Tab separated values) file consisting of only numbers. So this
-can be given as input for the neural network without any problem. With the available list
-of permissions, intents, API calls etc., 916 features are obtained from a single android
-application. All the permissions, intents, API calls etc., which are not available in the list
-are counted as other permissions, other intents, other API calls etc., respectively.
+.smali file and converted into a TSV (Tab separated values) file. This TSV file is
+then encoded into another TSV file consisting of only numbers, so it can be given
+as input for the neural network without any problem. All intermediate and final
+feature files use the TSV format to avoid confusion with CSV files. With the
+available list of permissions, intents, API calls etc., 916 features are obtained
+from a single android application. All the permissions, intents, API calls etc.,
+which are not available in the list are counted as other permissions, other
+intents, other API calls etc., respectively.
 
 # Feature Selection
 Among the 916 available features some of the permissions, intents, API calls etc.,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of malware and hence it is an important feature.
 
 # Feature Encoding
 The above-mentioned features are extracted from the AndroidManifest.xml and
-.smali file and converted into a TSV (Tab separated values) file. This TSV file is
+.smali file and converted into a TSV (Tab Separated Values) file. This TSV file is
 then encoded into another TSV file consisting of only numbers, making it suitable
 as input for the neural network. All intermediate and final
 feature files use the TSV format to avoid confusion with CSV files. With the

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ of malware and hence it is an important feature.
 # Feature Encoding
 The above-mentioned features are extracted from the AndroidManifest.xml and
 .smali file and converted into a TSV (Tab separated values) file. This TSV file is
-then encoded into another TSV file consisting of only numbers, so it can be given
-as input for the neural network without any problem. All intermediate and final
+then encoded into another TSV file consisting of only numbers, making it suitable
+as input for the neural network. All intermediate and final
 feature files use the TSV format to avoid confusion with CSV files. With the
 available list of permissions, intents, API calls etc., 916 features are obtained
 from a single android application. All the permissions, intents, API calls etc.,


### PR DESCRIPTION
## Summary
- clarify that feature encoding uses TSV files throughout
- note that both intermediate and final feature files are TSV

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f38513da08328a966ef50fd14511e