### PR TITLE
Use app-specific feature files in CSV builder

### DIFF
--- a/CsvCreator.py
+++ b/CsvCreator.py
@@ -13,8 +13,6 @@ import pandas as pd
 cwd = os.getcwd()
 dirs = os.listdir(cwd + "/appsF")
 
-j = "appsF/"  + dirs[0] + "/features.tsv"
-
 
 data_set = open("data.tsv", 'w')
 data_set.write("App\t, Permissions\t Categories\t Activities\t Activity Aliases\t Uses Permissions\t Uses Features\t datas\t Meta Datas\t Providers\t Receivers\t Services\t Actions \n")
@@ -23,7 +21,7 @@ data_set.write("App\t, Permissions\t Categories\t Activities\t Activity Aliases\
 for app in dirs:
     app_ = "appsF/"  + app + "/features.tsv"
     print(app)
-    data = pd.read_csv(j, sep = '\t')
+    data = pd.read_csv(app_, sep='\t')
     data_set.write(str(app) + "\t ")
     for i in range(data.shape[1]):
         print i


### PR DESCRIPTION
## Summary
- Fix dataset generator to read each app's own `features.tsv` file instead of reusing the first app's file
- Remove unused variable `j`

## Testing
- `python /tmp/CsvCreator_tmp.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas due to 403 Forbidden proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688f38869f8c8328a655e27182b638ac